### PR TITLE
Give control of download logic to sources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.time.Instant
 
 group = "dev.ddlproxy"
-version = "2.1.0"
+version = "2.1.1"
 
 val ktor_version = "3.2.1"
 val kotlin_coroutines_version = "1.10.2"

--- a/src/main/kotlin/dev/ddlproxy/AppConfig.kt
+++ b/src/main/kotlin/dev/ddlproxy/AppConfig.kt
@@ -1,6 +1,7 @@
 package dev.ddlproxy
 
 import dev.ddlproxy.model.DownloadSource
+import dev.ddlproxy.service.JDownloaderController
 import dev.ddlproxy.sources.AnimeTosho.AnimeToshoSource
 import dev.ddlproxy.sources.TokyoInsider.TokyoInsiderSource
 import io.ktor.client.HttpClient
@@ -50,9 +51,11 @@ class AppConfig {
     fun animeToshoSource(
         client: HttpClient,
         objectMapper: ObjectMapper,
+        jDownloaderController: JDownloaderController
     ) = AnimeToshoSource(
         client,
         objectMapper,
+        jDownloaderController
     )
 
     @Bean
@@ -64,8 +67,10 @@ class AppConfig {
     )
     fun tokyoInsiderSource(
         client: HttpClient,
+        jDownloaderController: JDownloaderController
     ) = TokyoInsiderSource(
         client,
+        jDownloaderController
     )
 
     enum class Source {

--- a/src/main/kotlin/dev/ddlproxy/model/DownloadSource.kt
+++ b/src/main/kotlin/dev/ddlproxy/model/DownloadSource.kt
@@ -5,9 +5,7 @@ import dev.ddlproxy.AppConfig
 interface DownloadSource {
     val name: AppConfig.Source
 
-    suspend fun search(query: String): List<Release>
+    suspend fun search(query: String, season: Int? = null, episode: Int? = null): List<Release>
     suspend fun getRecent(): List<Release>
-    suspend fun getLinks(identifier: String): List<LinkGroup>
-
-    fun getHostPriority(host: String): Int = Int.MAX_VALUE
+    suspend fun download(identifier: String)
 }

--- a/src/main/kotlin/dev/ddlproxy/service/DownloadService.kt
+++ b/src/main/kotlin/dev/ddlproxy/service/DownloadService.kt
@@ -2,7 +2,6 @@ package dev.ddlproxy.service
 
 import dev.ddlproxy.model.Release
 import dev.ddlproxy.model.DownloadSource
-import dev.ddlproxy.model.LinkGroup
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -10,7 +9,6 @@ import org.springframework.util.MultiValueMap
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import kotlinx.coroutines.*
-import org.jsoup.nodes.Entities
 import java.io.StringWriter
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -19,14 +17,11 @@ import javax.xml.transform.OutputKeys
 import javax.xml.transform.TransformerFactory
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
-import kotlin.time.toJavaInstant
 
 @Service
 class DownloadService(
     private val sources: List<DownloadSource>,
     @param:Value($$"${base.url}") private val rawBaseUrl: String,
-    private val jDownloaderController: JDownloaderController,
-    @param:Value($$"${download.folder}") private val downloadFolder: String
 ) {
     private val logger = LoggerFactory.getLogger(DownloadService::class.java)
 
@@ -34,7 +29,27 @@ class DownloadService(
 
     suspend fun handleQuery(params: MultiValueMap<String, String>): String {
         return try {
-            val query = buildQuery(params)
+            val qValues = mutableListOf<String>()
+            var season: Int? = null
+            var episode: Int? = null
+
+            for ((key, values) in params) {
+                when {
+                    key.equals("season", true) && values.isNotEmpty() -> {
+                        season = values.first().toIntOrNull()
+                    }
+
+                    key.equals("ep", true) && values.isNotEmpty() -> {
+                        episode = values.first().toIntOrNull()
+                    }
+
+                    key.equals("q", true) -> qValues.addAll(values)
+                }
+            }
+
+            if (qValues.isEmpty()) return ""
+
+            val query = qValues.joinToString(" ")
 
             val results = coroutineScope {
                 sources.map { source ->
@@ -43,7 +58,7 @@ class DownloadService(
                             if (query.isBlank()) {
                                 source.getRecent()
                             } else {
-                                source.search(query)
+                                source.search(query, season, episode)
                             }
                         }.getOrElse {
                             logger.warn("Source failed: {}", source.name, it)
@@ -69,50 +84,11 @@ class DownloadService(
         }
 
         val links = try {
-            source.getLinks(identifier)
+            source.download(identifier)
         } catch (e: Exception) {
             logger.error("Failed to fetch links for {}:{}", sourceName, identifier, e)
             return
         }
-
-        val sortedLinks = links.sortedBy { source.getHostPriority(it.host) }
-
-        sortedLinks.firstOrNull { jDownloaderController.isLinkOnline(it) }?.let { result ->
-            logger.debug("Downloading from: {}", result.links)
-            jDownloaderController.download(result, downloadFolder)
-        } ?: run {
-            logger.warn("No valid links found for {}:{}", sourceName, identifier)
-        }
-    }
-
-    private fun buildQuery(params: MultiValueMap<String, String>): String {
-        val qValues = mutableListOf<String>()
-        var season: String? = null
-        var episode: String? = null
-
-        for ((key, values) in params) {
-            when {
-                key.equals("season", true) && values.isNotEmpty() -> {
-                    season = "S%02d".format(values.first().toIntOrNull() ?: return "")
-                }
-
-                key.equals("ep", true) && values.isNotEmpty() -> {
-                    episode = "E%02d".format(values.first().toIntOrNull() ?: return "")
-                }
-
-                key.equals("q", true) -> qValues.addAll(values)
-            }
-        }
-
-        if (qValues.isEmpty()) return ""
-
-        val suffix = buildString {
-            if (season != null) append(season)
-            if (episode != null) append(episode)
-            if (isNotEmpty()) insert(0, " ")
-        }
-
-        return qValues.joinToString(" ") { it + suffix }
     }
 
     private fun buildTorznabFeed(releases: List<Release>): String {

--- a/src/main/kotlin/dev/ddlproxy/service/JDownloaderController.kt
+++ b/src/main/kotlin/dev/ddlproxy/service/JDownloaderController.kt
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service
 import org.springframework.web.client.RestTemplate
 import tools.jackson.databind.ObjectMapper
 import org.springframework.http.HttpStatus
-import java.nio.charset.StandardCharsets
 
 sealed class LinkState {
     object Online : LinkState()
@@ -25,7 +24,8 @@ sealed class LinkState {
 class JDownloaderController(
     private val restTemplate: RestTemplate,
     private val objectMapper: ObjectMapper,
-    @Value($$"${jdownloader.api.url}") jdownloaderApiUrlRaw: String
+    @Value($$"${jdownloader.api.url}") jdownloaderApiUrlRaw: String,
+    @param:Value($$"${download.folder}") private val downloadFolder: String
 ) {
 
     private val logger = LoggerFactory.getLogger(JDownloaderController::class.java)
@@ -166,13 +166,27 @@ class JDownloaderController(
         logger.debug("Linkgrabber list cleared successfully")
     }
 
-    fun download(links: LinkGroup, destinationFolder: String) {
+    /**
+     * Starts downloading the given [LinkGroup] if online.
+     *
+     * @param linkGroup The link group to download.
+     * @param skipOnlineCheck Do not check if link is online before attempting download
+     *
+     * Use [download] with a [List] of [LinkGroup]s if you have multiple and want
+     * to automatically pick the first online link group.
+     */
+    fun download(linkGroup: LinkGroup, skipOnlineCheck: Boolean = false) {
+        if (!skipOnlineCheck && !isLinkOnline(linkGroup)) {
+            logger.warn("No valid links found for {}", linkGroup)
+            return
+        }
+
         clearList()
 
         val payload = mapOf(
-            "links" to links.links.joinToString("\n"),
+            "links" to linkGroup.links.joinToString("\n"),
             "autostart" to true,
-            "destinationFolder" to destinationFolder,
+            "destinationFolder" to downloadFolder,
             "enabled" to true,
             "autoExtract" to true,
             "overwritePackagizerRules" to true
@@ -186,9 +200,25 @@ class JDownloaderController(
             )
 
             logger.trace("JDownloader response: {}", response.body)
-            logger.info("Started download: {}", links)
+            logger.info("Started download: {}", linkGroup)
         } catch (e: Exception) {
-            logger.error("Failed to start download: {}", links, e)
+            logger.error("Failed to start download: {}", linkGroup, e)
         }
+    }
+
+    /**
+     * Starts downloading the first online [LinkGroup] in the given list.
+     *
+     * @param linkGroups The list of link groups to try. This should be sorted in the order you want them checked.
+     *
+     * Use [download] with a single [LinkGroup] if you only have one to download.
+     */
+    fun download(linkGroups: List<LinkGroup>) {
+        val link = linkGroups.firstOrNull { isLinkOnline(it) } ?: run {
+            logger.warn("No valid links found for {}", linkGroups)
+            return
+        }
+
+        download(link)
     }
 }

--- a/src/main/kotlin/dev/ddlproxy/sources/AnimeTosho/AnimeTosho.kt
+++ b/src/main/kotlin/dev/ddlproxy/sources/AnimeTosho/AnimeTosho.kt
@@ -4,6 +4,7 @@ import dev.ddlproxy.AppConfig
 import dev.ddlproxy.model.Release
 import dev.ddlproxy.model.DownloadSource
 import dev.ddlproxy.model.LinkGroup
+import dev.ddlproxy.service.JDownloaderController
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
@@ -18,7 +19,8 @@ import java.time.Instant
 
 class AnimeToshoSource(
     private val client: HttpClient,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val jDownloaderController: JDownloaderController,
 ) : DownloadSource {
 
     override val name = AppConfig.Source.AnimeTosho
@@ -27,11 +29,21 @@ class AnimeToshoSource(
 
     private val baseUrl = "https://feed.animetosho.org/json"
 
-    override suspend fun search(query: String): List<Release> {
-        val results = getJson("$baseUrl?q=${encode(query)}")
+    override suspend fun search(query: String, season: Int?, episode: Int?): List<Release> {
+        var fullQuery = query
+
+        if (season != null) {
+            fullQuery += " S$season"
+        }
+
+        if (episode != null) {
+            fullQuery += "E$episode"
+        }
+
+        val results = getJson("$baseUrl?q=${encode(fullQuery)}")
 
         if (!results.isArray || results.isEmpty) {
-            logger.warn("No results found for query: {}", query)
+            logger.warn("No results found for query: {}", fullQuery)
             return emptyList()
         }
 
@@ -83,11 +95,11 @@ class AnimeToshoSource(
         )
     }
 
-    override suspend fun getLinks(identifier: String): List<LinkGroup> {
+    override suspend fun download(identifier: String) {
         val torrentId = identifier.toIntOrNull()
         if (torrentId == null) {
             logger.error("Invalid identifier: {}", identifier)
-            return emptyList()
+            return
         }
 
         val torrentData = getJson("$baseUrl?show=torrent&id=$torrentId")
@@ -96,10 +108,12 @@ class AnimeToshoSource(
 
         logger.trace("Extracted link groups: {}", linkGroups)
 
-        return linkGroups
+        val sortedLinks = linkGroups.sortedBy { getHostPriority(it.host) }
+
+        jDownloaderController.download(sortedLinks)
     }
 
-    override fun getHostPriority(host: String): Int {
+    private fun getHostPriority(host: String): Int {
         return when {
             host.contains("gofile", ignoreCase = true) -> 1
             host.contains("buzzheavier", ignoreCase = true) -> 2

--- a/src/main/kotlin/dev/ddlproxy/sources/AnimeTosho/AnimeTosho.kt
+++ b/src/main/kotlin/dev/ddlproxy/sources/AnimeTosho/AnimeTosho.kt
@@ -30,14 +30,17 @@ class AnimeToshoSource(
     private val baseUrl = "https://feed.animetosho.org/json"
 
     override suspend fun search(query: String, season: Int?, episode: Int?): List<Release> {
+        logger.trace("handling search for S${season}E${episode}")
         var fullQuery = query
 
         if (season != null) {
-            fullQuery += " S$season"
+            val paddedSeason = season.toString().padStart(2, '0')
+            fullQuery += " S$paddedSeason"
         }
 
         if (episode != null) {
-            fullQuery += "E$episode"
+            val paddedEpisode = episode.toString().padStart(2, '0')
+            fullQuery += "E$paddedEpisode"
         }
 
         val results = getJson("$baseUrl?q=${encode(fullQuery)}")

--- a/src/main/kotlin/dev/ddlproxy/sources/TokyoInsider/TokyoInsider.kt
+++ b/src/main/kotlin/dev/ddlproxy/sources/TokyoInsider/TokyoInsider.kt
@@ -4,6 +4,7 @@ import dev.ddlproxy.AppConfig
 import dev.ddlproxy.model.DownloadSource
 import dev.ddlproxy.model.LinkGroup
 import dev.ddlproxy.model.Release
+import dev.ddlproxy.service.JDownloaderController
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
@@ -27,7 +28,8 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 class TokyoInsiderSource(
-    private val client: HttpClient
+    private val client: HttpClient,
+    private val jDownloaderController: JDownloaderController,
 ) : DownloadSource {
 
     override val name = AppConfig.Source.TokyoInsider
@@ -36,7 +38,7 @@ class TokyoInsiderSource(
 
     private val baseUrl = "https://www.tokyoinsider.com"
 
-    override suspend fun search(query: String): List<Release> {
+    override suspend fun search(query: String, season: Int?, episode: Int?): List<Release> {
         logger.debug("Starting search for query: '$query'")
         val url = "$baseUrl/anime/list"
 
@@ -118,8 +120,8 @@ class TokyoInsiderSource(
 
     }
 
-    override suspend fun getLinks(identifier: String): List<LinkGroup> {
-        return listOf(
+    override suspend fun download(identifier: String) {
+        jDownloaderController.download(
             LinkGroup(
                 host = "TokyoInsider",
                 links = listOf(identifier)
@@ -127,7 +129,7 @@ class TokyoInsiderSource(
         )
     }
 
-    private suspend fun extractReleases(animePageDoc: Document, query: String): List<Release> {
+    private suspend fun extractReleases(animePageDoc: Document, query: String, episode: Int? = null): List<Release> {
         logger.trace("Extracting releases from document")
         val episodes = animePageDoc
             .select(".download-link")
@@ -142,7 +144,9 @@ class TokyoInsiderSource(
         val top = episodes
             .asSequence()
             .map { (title, url) ->
-                val s = score(query, title)
+                val s = score(query, title) +
+                        if (episode != null && url.contains("/episode/$episode")) 100 else 0
+
                 Triple(title, url, s)
             }
             .filter { it.third > 0 }


### PR DESCRIPTION
Instead of hard wiring in JDownloader logic, control over downloading is now given to the source. This will allow more flexibility for sources in the future. The JDownloader api was also slightly simplified in response to this.

Also sources are now given the requested season and episode in the search function as parameters rather than in the query string. This should let sources search more accurately.